### PR TITLE
feat: make dagula work on node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,16 +8,30 @@ on:
       - main
 
 jobs:
-  test:
-    name: Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: bahmutov/npm-install@v1
+          cache: 'npm'
+      - run: npm ci
       - name: Lint
-        run: npm run lint
+
+  test:
+    name: Test Node v${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 16, 18 ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+          cache: 'npm'
+      - run: npm ci
       - name: Test
         run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18
           cache: 'npm'
       - run: npm ci
-      - name: Lint
+      - run: npm run lint
 
   test:
     name: Test Node v${{ matrix.node }}
@@ -33,5 +33,4 @@ jobs:
           node-version: ${{ matrix.version }}
           cache: 'npm'
       - run: npm ci
-      - name: Test
-        run: npm test
+      - run: npm test


### PR DESCRIPTION
node 16 is LTS. `signal.throwIfAborted` landed in node 17. This PR makes dagular work on node 16 and tests it.

see: https://nodejs.org/api/globals.html#abortsignalthrowifaborted
see: https://github.com/nodejs/node/commit/3f72c72bbb89154bc15fbcef7ccbe3cf0dd017ba

Also the `setup-node@v3` action now supports caching deps, so we drop `bahmutov/npm-install@v1`.
see: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>