### PR TITLE
feat: add `ls` and `tree` commands

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -155,11 +155,11 @@ cli.command('tree <cid>')
           node.nodes.push(target)
         }
       }
+      console.log(archy(root))
     } finally {
       controller.clear()
+      await libp2p.stop()
     }
-    console.log(archy(root))
-    await libp2p.stop()
   })
 
 cli.parse(process.argv)

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const DEFAULT_PEER = new Multiaddr('/dns4/peer.ipfs-elastic-provider-aws.com/tcp
 const log = debug('dagular')
 
 /** @type {BlockDecoders} */
-const Decoders = {
+export const Decoders = {
   [raw.code]: raw,
   [dagPb.code]: dagPb,
   [dagCbor.code]: dagCbor,
@@ -80,11 +80,14 @@ export class Dagula {
       })
       const nextCids = []
       for await (const { cid, bytes } of fetchBlocks(cids)) {
-        yield { cid, bytes }
         const decoder = this.#decoders[cid.code]
-        if (!decoder) throw new Error(`unknown codec: ${cid.code}`)
+        if (!decoder) {
+          yield { cid, bytes }
+          throw new Error(`unknown codec: ${cid.code}`)
+        }
         log('decoding block %s', cid)
         const block = await Block.decode({ bytes, codec: decoder, hasher })
+        yield block
         for (const [, cid] of block.links()) {
           nextCids.push(cid)
         }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const DEFAULT_PEER = new Multiaddr('/dns4/peer.ipfs-elastic-provider-aws.com/tcp
 const log = debug('dagular')
 
 /** @type {BlockDecoders} */
-export const Decoders = {
+const Decoders = {
   [raw.code]: raw,
   [dagPb.code]: dagPb,
   [dagCbor.code]: dagCbor,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@libp2p/websockets": "^3.0.1",
         "@multiformats/multiaddr": "^10.3.3",
         "@web3-storage/fast-unixfs-exporter": "^0.2.0",
+        "archy": "^1.0.0",
         "conf": "^10.1.2",
         "debug": "^4.3.4",
         "it-length-prefixed": "^7.0.1",
@@ -1324,6 +1325,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -8116,6 +8122,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "arg": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@libp2p/websockets": "^3.0.1",
     "@multiformats/multiaddr": "^10.3.3",
     "@web3-storage/fast-unixfs-exporter": "^0.2.0",
+    "archy": "^1.0.0",
     "conf": "^10.1.2",
     "debug": "^4.3.4",
     "it-length-prefixed": "^7.0.1",


### PR DESCRIPTION
- `dagula ls` – I wanted a quick way to check if a remote node has an entire DAG without needing to save the block data locally (see #2)
- `dagula tree` - You wanted a pretty way to see a DAG

So why not both!? This PR takes the liberty of yeilding the decoded Block rather than the `{ cid, bytes }` combo, so it can access the links info. It's neat because a decoded Block also as cid, and bytes, so it work! 🎉

On a snapshot of the dagula source we get:

### `ls`
```console
❯ ./bin.js ls bafybeianow3xqswlzqmmqp4enj4mul3snpg52rya4rvpanip5tycw43elm
bafybeianow3xqswlzqmmqp4enj4mul3snpg52rya4rvpanip5tycw43elm
bafkreifjt56wbljg574jp3ij3iz56rr3ligwf3tmcwmyqufabuhytiirq4
bafkreibsrowqy5n4jpr7en25pepmw2psg6mnhoxzm6yodqubw6uqkl3nau
bafkreid52wbs2t5bjl7k4jqvcmvmpwnwifnvresgdmstcpwhw3h2wb4h6e
bafkreienidxwfi26e7zz54wgkugorvzuugrkaijievwwbrjal37qsnmvye
bafkreicaz5es35z2z2rpu63wukkg2ij2vctmsogmviudlbeb4dfpjfya2u
bafkreicsmlfxu3b4d2ubhlkk5bjo46nnxs5foee7x5bndnn5tpq7ghpo34
bafybeife4dxf7mfar2qsqgexkhze6b4w43a46rvfeoesnkooc5ktdc4uim
bafkreieaixgg2evxchw4wwzzcegecjayq2dn7ka7dblps425royn7ujg5m
bafkreiekuaqztmk7upvdftvq5lwjfmwbg3ffsl7l2oxayrjlqlbj3egcwm
bafkreihblq7u4qvbte34agifm7cjhaerpwxt5q53xy4jnfw47im5hzlqdi
bafkreifpiqrfihldtiziyos6u2k35lf45qrewid2hoylaj5uyi35u5xmbq
bafkreihrp4ceuqkpfl7ytv4kk5qn2ztsyi2weka6gmc346iixlqzupmw5a
bafkreiencnfom77cudkikff7dyy7osc5e22vqset7vpotcyudv274xilq4
bafkreihvxng4xlbbpqrd2ob67btegs3pnocsqf6bq7ahqqo7ofyx7payhy
bafkreic3qg76debp4uwj5hnfpawaqbcv6qyptwn2sz4oxp73md66kdtree
bafkreia5kv2iq3ewgdravhtrlz7zeywhm6cynwx5xieggjl4dlysv772t4
bafkreiejwjgkdtnox6pulwpa4gyjyuczbz4t3k7waeq64i5lgbxjdfifri
```

### `tree`
```console
❯ ./bin.js tree bafybeianow3xqswlzqmmqp4enj4mul3snpg52rya4rvpanip5tycw43elm
bafybeianow3xqswlzqmmqp4enj4mul3snpg52rya4rvpanip5tycw43elm
├── bafkreifpiqrfihldtiziyos6u2k35lf45qrewid2hoylaj5uyi35u5xmbq
├── bafkreic3qg76debp4uwj5hnfpawaqbcv6qyptwn2sz4oxp73md66kdtree
├── bafkreihrp4ceuqkpfl7ytv4kk5qn2ztsyi2weka6gmc346iixlqzupmw5a
├── bafkreicaz5es35z2z2rpu63wukkg2ij2vctmsogmviudlbeb4dfpjfya2u
├── bafkreihblq7u4qvbte34agifm7cjhaerpwxt5q53xy4jnfw47im5hzlqdi
├─┬ bafybeife4dxf7mfar2qsqgexkhze6b4w43a46rvfeoesnkooc5ktdc4uim
│ ├── bafkreia5kv2iq3ewgdravhtrlz7zeywhm6cynwx5xieggjl4dlysv772t4
│ └── bafkreiejwjgkdtnox6pulwpa4gyjyuczbz4t3k7waeq64i5lgbxjdfifri
├── bafkreieaixgg2evxchw4wwzzcegecjayq2dn7ka7dblps425royn7ujg5m
├── bafkreienidxwfi26e7zz54wgkugorvzuugrkaijievwwbrjal37qsnmvye
├── bafkreid52wbs2t5bjl7k4jqvcmvmpwnwifnvresgdmstcpwhw3h2wb4h6e
├── bafkreifjt56wbljg574jp3ij3iz56rr3ligwf3tmcwmyqufabuhytiirq4
├── bafkreicsmlfxu3b4d2ubhlkk5bjo46nnxs5foee7x5bndnn5tpq7ghpo34
├── bafkreibsrowqy5n4jpr7en25pepmw2psg6mnhoxzm6yodqubw6uqkl3nau
├── bafkreihvxng4xlbbpqrd2ob67btegs3pnocsqf6bq7ahqqo7ofyx7payhy
├── bafkreiencnfom77cudkikff7dyy7osc5e22vqset7vpotcyudv274xilq4
└── bafkreiekuaqztmk7upvdftvq5lwjfmwbg3ffsl7l2oxayrjlqlbj3egcwm
```

_i believe we are seeing the `gen` dir at bafybeife4dxf7mfar2qsqgexkhze6b4w43a46rvfeoesnkooc5ktdc4uim with 2 children..._ YES! IT TRUE https://bafybeife4dxf7mfar2qsqgexkhze6b4w43a46rvfeoesnkooc5ktdc4uim.ipfs.w3s.link

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>